### PR TITLE
解决同类型type切换MP4时，第一帧是上一个mp4最后一帧的问题

### DIFF
--- a/web/src/webgl-render-vap.ts
+++ b/web/src/webgl-render-vap.ts
@@ -93,6 +93,10 @@ export default class WebglRenderVap extends VapVideo {
       gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
       gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     }
+
+    // 清除界面，解决同类型type切换MP4时，第一帧是上一个mp4最后一帧的问题
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
     if (gl) {
       gl.viewport(0, 0, canvas.width, canvas.height);
       if (!vertexShader) {


### PR DESCRIPTION
如标题。 
在使用过成功，如果是反复播放type相同或者不同mp4。第一次之后的播放第一帧都是上一次播放的mp4的最后一帧。
故，在初始化webgl之前，先清除界面。