### PR TITLE
fix: iOS 10.1.1 系统使用QGHWDMetalShaderSourceDefine.h中着色字符串时的异常

### DIFF
--- a/iOS/QGVAPlayer/QGVAPlayer/Shaders/QGHWDMetalShaderSourceDefine.h
+++ b/iOS/QGVAPlayer/QGVAPlayer/Shaders/QGHWDMetalShaderSourceDefine.h
@@ -102,7 +102,7 @@ SHADER_STRING(
                   float2 maskTextureCoordinate;
               } VAPAttachmentRasterizerData;
               
-              float3 RGBColorFromYuvTextures(sampler textureSampler, float2 coordinate, texture2d<float> texture_luma, texture2d<float> texture_chroma, matrix_float3x3 rotationMatrix, float2 offset) {
+              static float3 RGBColorFromYuvTextures(sampler textureSampler, float2 coordinate, texture2d<float> texture_luma, texture2d<float> texture_chroma, matrix_float3x3 rotationMatrix, float2 offset) {
                   
                   float3 color;
                   color.x = texture_luma.sample(textureSampler, coordinate).r;
@@ -110,7 +110,7 @@ SHADER_STRING(
                   return float3(rotationMatrix * color);
               }
               
-              float4 RGBAColor(sampler textureSampler, float2 colorCoordinate, float2 alphaCoordinate, texture2d<float> lumaTexture, texture2d<float> chromaTexture, constant ColorParameters *colorParameters) {
+              static float4 RGBAColor(sampler textureSampler, float2 colorCoordinate, float2 alphaCoordinate, texture2d<float> lumaTexture, texture2d<float> chromaTexture, constant ColorParameters *colorParameters) {
                   matrix_float3x3 rotationMatrix = colorParameters[0].matrix;
                   float2 offset = colorParameters[0].offset;
                   float3 color = RGBColorFromYuvTextures(textureSampler, colorCoordinate, lumaTexture, chromaTexture, rotationMatrix, offset);


### PR DESCRIPTION
iOS 10.1.1 系统使用QGHWDMetalShaderSourceDefine.h中着色字符串时, loadHWDLibrary时, 会有如下 warning，最终导致触发断言。
Error Domain=MTLLibraryErrorDomain Code=4 "Compilation succeeded with: 
program_source:3:1176: warning: no previous prototype for function 'RGBColorFromYuvTextures'
program_source:3:1553: warning: no previous prototype for function 'RGBAColor'
