### PR TITLE
fix: 解决 VapxTool 生成视频时出现花屏的问题

### DIFF
--- a/tool/vapxTool/VapxTool/controllers/VapxAlphaExtractor.m
+++ b/tool/vapxTool/VapxTool/controllers/VapxAlphaExtractor.m
@@ -152,27 +152,28 @@
     }
     free(rawData);
     
-    CGDataProviderRef rgbProvider = CGDataProviderCreateWithData(NULL, rgbData, width*height*4, NULL);
-    
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault | (CGBitmapInfo)kCGImageAlphaLast;
     CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
+    
+    // 生成 RGB 图片
+    CGDataProviderRef rgbProvider = CGDataProviderCreateWithData(NULL, rgbData, width*height*4, NULL);
     CGImageRef rgbImageRef = CGImageCreate(width,  height, 8, 32, 4*width,colorSpace, bitmapInfo, rgbProvider,NULL,NO, renderingIntent);
     NSImage *rgbImage = [[NSImage alloc] initWithCGImage:rgbImageRef size: rect.size];
+    NSString *rgbDir = [self.resourceDirectory stringByAppendingPathComponent:@"rbgImages"];
+    [self saveImage:rgbImage atPath:[rgbDir stringByAppendingPathComponent:name]];
     CGImageRelease(rgbImageRef);
     free(rgbData);
     CGDataProviderRelease(rgbProvider);
-    
+     
+    // 生成 Alpha 图片
     CGDataProviderRef alphaProvider = CGDataProviderCreateWithData(NULL, alphaData, width*height*4, NULL);
     CGImageRef alphaImageRef = CGImageCreate(width,  height, 8, 32, 4*width,colorSpace, bitmapInfo, alphaProvider,NULL,NO, renderingIntent);
     NSImage *alphaImage = [[NSImage alloc] initWithCGImage:alphaImageRef size:rect.size];
+    NSString *alphaDir = [self.resourceDirectory stringByAppendingPathComponent:@"alphaImages"];
+    [self saveImage:alphaImage atPath:[alphaDir stringByAppendingPathComponent:name]];
     CGImageRelease(alphaImageRef);
     free(alphaData);
     CGDataProviderRelease(alphaProvider);
-    
-    NSString *alphaDir = [self.resourceDirectory stringByAppendingPathComponent:@"alphaImages"];
-    NSString *rgbDir = [self.resourceDirectory stringByAppendingPathComponent:@"rbgImages"];
-    [self saveImage:alphaImage atPath:[alphaDir stringByAppendingPathComponent:name]];
-    [self saveImage:rgbImage atPath:[rgbDir stringByAppendingPathComponent:name]];
 }
 
 - (NSRect)alphaRectForPosition:(VapxAlphaPostion)position rgbSize:(NSSize)size alphaScale:(CGFloat)scale {


### PR DESCRIPTION
解决办法：
之前的做法是先释放 RGB 和 Alpha 数据再保存，这样会导致偶现生成的 RGB 和 Alpha 图片会出现花屏，导致最后生成的视频带有雪花的问题，所以调整了顺序，先保存再释放即可解决问题。

**下面为修改前出现雪花的效果：**
[![y0lgk6.png](https://s3.ax1x.com/2021/02/10/y0lgk6.png)](https://imgchr.com/i/y0lgk6)
（simple_demo 第 54 帧）


**下面为修改后的效果：**
[![y0l0l4.png](https://s3.ax1x.com/2021/02/10/y0l0l4.png)](https://imgchr.com/i/y0l0l4)
（simple_demo 第 54 帧）

