### PR TITLE
bugfix：使用vapc box解析到的fps数据作为默认帧率

### DIFF
--- a/iOS/QGVAPlayer/QGVAPlayer/Classes/Controllers/QGVAPConfigManager.m
+++ b/iOS/QGVAPlayer/QGVAPlayer/Classes/Controllers/QGVAPConfigManager.m
@@ -167,7 +167,8 @@
     commonInfo.alphaAreaRect = a_frame ? [a_frame hwd_rectValue] : CGRectZero;
     commonInfo.rgbAreaRect = rgb_frame ? [rgb_frame hwd_rectValue] : CGRectZero;
     configModel.info = commonInfo;
-    
+    //更新parser的fps信息
+    _fileInfo.mp4Parser.fps = fps;
     if (!sourcesArr) {
         VAP_Error(kQGVAPModuleCommon, @"has no sourcesArr:%@", configDic);
         return ;


### PR DESCRIPTION
目前iOS计算默认fps时不是直接取值，而是通过视频帧数量除以时长。如果视频与音频时长不一致，则会导致播放卡顿，故此处添加从vapc box取帧率逻辑