### PR TITLE
bugfix: 将vapc块的插入位置后移，解决OPPO R系统上音频播放异常的问题

### DIFF
--- a/Android/PlayerProj/animtool/src/main/java/com/tencent/qgame/playerproj/animtool/AnimTool.java
+++ b/Android/PlayerProj/animtool/src/main/java/com/tencent/qgame/playerproj/animtool/AnimTool.java
@@ -393,11 +393,11 @@ public class AnimTool {
     /**
      * 合并vapc.bin到mp4里
      */
-    private boolean mergeBin2Mp4(CommonArg commonArg, String inputFile, String tempVideoFile, String videoPath) throws Exception{
-        String[] cmd = new String[] {commonArg.mp4editCmd, "--insert", ":"+inputFile+":1", videoPath + tempVideoFile, videoPath + VIDEO_FILE};
+    private boolean mergeBin2Mp4(CommonArg commonArg, String inputFile, String tempVideoFile, String videoPath) throws Exception {
+        String[] cmd = new String[]{commonArg.mp4editCmd, "--insert", ":" + inputFile + ":3", videoPath + tempVideoFile, videoPath + VIDEO_FILE};
         TLog.i(TAG, "run mergeBin2Mp4");
         int result = ProcessUtil.run(cmd);
-        TLog.i(TAG, "mergeBin2Mp4 result=" + (result == 0? "success" : "fail"));
+        TLog.i(TAG, "mergeBin2Mp4 result=" + (result == 0 ? "success" : "fail"));
         return result == 0;
     }
 


### PR DESCRIPTION
[issue52](https://github.com/Tencent/vap/issues/52), [issue67](https://github.com/Tencent/vap/issues/67)

OPPO/Realme/OnePlus部分机型的Android 11(R)上，系统使用了parseBox机制来读取视频信息，要求Box需要按照ftyp->moov的顺序读取，中间不能插入其他box，否则会导致读取音频track失败，出现mime=audio/ffmpeg；所以这里将vapc后移，放在moov之后，从而不影响系统解析。