### PR TITLE
fix(iOS): MTLRenderCommandEncoder释放前需要调用-[MTLRenderCommandEncoder end…

### DIFF
--- a/iOS/QGVAPlayer/QGVAPlayer/Classes/Views/Metal/Vapx/QGVAPMetalRenderer.m
+++ b/iOS/QGVAPlayer/QGVAPlayer/Classes/Views/Metal/Vapx/QGVAPMetalRenderer.m
@@ -120,6 +120,7 @@
     }
     if (self.vertexBuffer == nil || self.yuvMatrixBuffer == nil) {
         VAP_Error(kQGVAPModuleCommon, @"quit rendering cuz vertexBuffer:%p or yuvMatrixBuffer:%p is nil!", self.vertexBuffer, self.yuvMatrixBuffer);
+        [renderEncoder endEncoding];
         return ;
     }
     


### PR DESCRIPTION
…Encoding], 避免触发断言‘Command encoder released without endEncoding’