### PR TITLE
perf: 增大bufSize，提升输出视频质量

### DIFF
--- a/Android/PlayerProj/animtool/src/main/java/com/tencent/qgame/playerproj/animtool/AnimTool.java
+++ b/Android/PlayerProj/animtool/src/main/java/com/tencent/qgame/playerproj/animtool/AnimTool.java
@@ -328,7 +328,7 @@ public class AnimTool {
                         "-profile:v", "main",
                         "-level", "4.0",
                         "-tag:v", "hvc1",
-                        "-bufsize", "2000k",
+                        "-bufsize", "4000k",
                         "-y", videoPath + TEMP_VIDEO_FILE};
             } else {
                 cmd = new String[] {commonArg.ffmpegCmd, "-framerate", String.valueOf(commonArg.fps),
@@ -339,7 +339,7 @@ public class AnimTool {
                         "-profile:v", "main",
                         "-level", "4.0",
                         "-tag:v", "hvc1",
-                        "-bufsize", "2000k",
+                        "-bufsize", Integer.toString(commonArg.bitrate * 2) + "k",
                         "-y", videoPath + TEMP_VIDEO_FILE};
             }
 
@@ -353,7 +353,7 @@ public class AnimTool {
                         "-profile:v", "main",
                         "-level", "4.0",
                         "-bf", "0",
-                        "-bufsize", "2000k",
+                        "-bufsize", "4000k",
                         "-y", videoPath + TEMP_VIDEO_FILE};
             } else {
                 cmd = new String[]{commonArg.ffmpegCmd, "-framerate", String.valueOf(commonArg.fps),
@@ -364,7 +364,7 @@ public class AnimTool {
                         "-profile:v", "main",
                         "-level", "4.0",
                         "-bf", "0",
-                        "-bufsize", "2000k",
+                        "-bufsize", Integer.toString(commonArg.bitrate * 2) + "k",
                         "-y", videoPath + TEMP_VIDEO_FILE};
             }
 


### PR DESCRIPTION
bufSize指定值太小，当固定码率指定较高时，这个很小的bufSize会导致编码输出结果质量下降，将其调整至1~2x的码率时可以显著提升视频质量。