### PR TITLE
fix: 修复 vap 在 OpenGLES 游戏场景下，会导致游戏里的纹理不会释放的问题

### DIFF
--- a/iOS/QGVAPlayer/QGVAPlayer/Classes/UIView+VAP.m
+++ b/iOS/QGVAPlayer/QGVAPlayer/Classes/UIView+VAP.m
@@ -128,6 +128,7 @@ NSInteger const VapMaxCompatibleVersion = 2;
         }
         [self.hwd_openGLView dispose];
         glFinish();
+        [EAGLContext setCurrentContext:nil];
     }
     if (self.hwd_metalView) {
         [self.hwd_metalView dispose];
@@ -146,7 +147,6 @@ NSInteger const VapMaxCompatibleVersion = 2;
     self.hwd_decodeConfig = nil;
     self.hwd_currentFrameInstance = nil;
     self.hwd_fileInfo = nil;
-    [EAGLContext setCurrentContext:nil];
 }
 
 //播放完成


### PR DESCRIPTION
我们的产品形态是，底部界面是 OpenGLES 渲染的游戏，顶部页面是 vap 视频（Metal播放）。当游戏结束时，是有逻辑把游戏纹理给清理掉的，但是由于 vap 在停止播放的逻辑里，把 GL 上下文给置为了空，此时会导致游戏里的纹理不能被清空了。而且看了这块的代码，Metal 播放的时候，其实是跟 GL 没有关系的。